### PR TITLE
[Blocked on upstream] Lex stropped keywords (`k#keyword` and `'k#keyword`)

### DIFF
--- a/src/cli/diagnostics.rs
+++ b/src/cli/diagnostics.rs
@@ -1,7 +1,7 @@
 use annotate_snippets as ann;
 use rasur::{
     error::{Error, ErrorKind, InvalidScalarPlace, List1},
-    lexer::IdentKind,
+    lexer::{IdentKind, IdentMode},
     parser::Fragment,
     span::{At as _, Span},
     token::{Repr, Token, TokenKind},
@@ -52,6 +52,18 @@ impl IntoDiag for Error {
             ErrorKind::InvalidFrontmatterTrailer => {
                 diag.title("extra characters after frontmatter closing")
             }
+            ErrorKind::InvalidIdent(IdentKind::Normal, IdentMode::Raw) => {
+                diag.title("invalid raw identifier")
+            }
+            ErrorKind::InvalidIdent(IdentKind::Normal, IdentMode::Keyword) => {
+                diag.title("invalid stropped keyword")
+            }
+            ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Raw) => {
+                diag.title("invalid raw ticked identifier")
+            }
+            ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Keyword) => {
+                diag.title("invalid stropped ticked keyword")
+            }
             ErrorKind::InvalidItemPrefix => diag.title("invalid item modifiers"),
             ErrorKind::InvalidLetChain => diag.title("invalid let-chain"),
             ErrorKind::InvalidLitSuffix => diag.title("invalid literal suffix"),
@@ -60,10 +72,6 @@ impl IntoDiag for Error {
                 diag.title("invalid operator following a boundary")
             }
             ErrorKind::InvalidOpAfterCast => diag.title("invalid operator following a cast"),
-            ErrorKind::InvalidRawIdent(IdentKind::Normal) => diag.title("invalid raw identifier"),
-            ErrorKind::InvalidRawIdent(IdentKind::Ticked) => {
-                diag.title("invalid raw ticked identifier")
-            }
             ErrorKind::InvalidScalar(char, place) => {
                 let place = match place {
                     InvalidScalarPlace::File => "",
@@ -74,7 +82,6 @@ impl IntoDiag for Error {
                 diag.title(format!("invalid scalar U+{:04X}{place}", char as u32))
             }
             ErrorKind::InvalidStrLitDelimiter => diag.title("invalid string literal delimiter"),
-            ErrorKind::InvalidStroppedKeyword => diag.title("invalid stropped keyword"),
             ErrorKind::InvalidTraitBoundModifier => diag.title("invalid trait bound modifier"),
             ErrorKind::InvalidTyPrefix => diag.title("invalid type modifiers"),
             ErrorKind::LifetimeObjectTyWithoutPlus => {

--- a/src/cli/diagnostics.rs
+++ b/src/cli/diagnostics.rs
@@ -74,6 +74,7 @@ impl IntoDiag for Error {
                 diag.title(format!("invalid scalar U+{:04X}{place}", char as u32))
             }
             ErrorKind::InvalidStrLitDelimiter => diag.title("invalid string literal delimiter"),
+            ErrorKind::InvalidStroppedKeyword => diag.title("invalid stropped keyword"),
             ErrorKind::InvalidTraitBoundModifier => diag.title("invalid trait bound modifier"),
             ErrorKind::InvalidTyPrefix => diag.title("invalid type modifiers"),
             ErrorKind::LifetimeObjectTyWithoutPlus => {

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -49,6 +49,7 @@ pub enum ErrorKind {
     InvalidRawIdent(IdentKind),
     InvalidScalar(char, InvalidScalarPlace),
     InvalidStrLitDelimiter,
+    InvalidStroppedKeyword,
     InvalidTraitBoundModifier,
     InvalidTyPrefix,
     LifetimeObjectTyWithoutPlus,

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -1,4 +1,9 @@
-use crate::{lexer::IdentKind, parser::Fragment, span::Span, token::TokenKind};
+use crate::{
+    lexer::{IdentKind, IdentMode},
+    parser::Fragment,
+    span::Span,
+    token::TokenKind,
+};
 pub use utility::List1;
 
 #[derive(Clone, Debug)]
@@ -40,16 +45,15 @@ pub enum ErrorKind {
     InvalidExtraFieldProjections,
     InvalidFrontmatterInfostring,
     InvalidFrontmatterTrailer,
+    InvalidIdent(IdentKind, IdentMode),
     InvalidItemPrefix,
     InvalidLetChain,
     InvalidLitSuffix,
     InvalidNumericIdent,
     InvalidOpAfterBoundary,
     InvalidOpAfterCast,
-    InvalidRawIdent(IdentKind),
     InvalidScalar(char, InvalidScalarPlace),
     InvalidStrLitDelimiter,
-    InvalidStroppedKeyword,
     InvalidTraitBoundModifier,
     InvalidTyPrefix,
     LifetimeObjectTyWithoutPlus,

--- a/src/lib/feature.rs
+++ b/src/lib/feature.rs
@@ -38,6 +38,7 @@ macro_rules! features {
 }
 
 features! {
+    __stropped_keywords #0, // FIXME: placeholder
     async_for_loop #118898,
     async_trait_bounds #62290,
     auto_traits #13231,

--- a/src/lib/lexer.rs
+++ b/src/lib/lexer.rs
@@ -4,6 +4,7 @@ mod transformer;
 use crate::{
     edition::Edition,
     error::{Error, ErrorKind, InvalidScalarPlace},
+    feature::Feature,
     span::{At as _, ByteIndex, Span},
     store::Store,
     token::{PathSegKeyword, Token, TokenKind},
@@ -453,26 +454,23 @@ impl<'sto, 'src> Lexer<'sto, 'src> {
                     }
                     self.advance();
 
-                    return match self.fin_lex_raw_ident(IdentKind::Ticked, start) {
-                        Some(()) => {
-                            // This is considered to be a 'reservation'.
-                            if let Some('\'') = self.peek() {
-                                self.error(
-                                    ErrorKind::TickFollowingRawTickedIdent,
-                                    self.span(self.index()),
-                                );
-                            }
+                    let kind = self.fin_lex_prefixed_ident(
+                        IdentKind::Ticked,
+                        None,
+                        |ident| !matches!(ident, PathSegKeyword!() | TokenKind::Underscore),
+                        ErrorKind::InvalidRawIdent,
+                        |_| TokenKind::TickedIdent,
+                        start,
+                    );
 
-                            TokenKind::TickedIdent
-                        }
-                        None => {
-                            self.error(
-                                ErrorKind::InvalidRawIdent(IdentKind::Ticked),
-                                self.span(start),
-                            );
-                            TokenKind::Error
-                        }
-                    };
+                    // This is considered to be a 'reservation'.
+                    if kind != TokenKind::Error // FIXME: HACK
+                        && let Some('\'') = self.peek()
+                    {
+                        self.error(ErrorKind::TickFollowingRawTickedIdent, self.span(self.index()));
+                    }
+
+                    return kind;
                 }
                 _ => return TokenKind::TickedIdent,
             }
@@ -593,13 +591,33 @@ impl<'sto, 'src> Lexer<'sto, 'src> {
                 self.advance();
                 return self.fin_lex_raw_guarded_str_lit(start);
             }
+            ("k", Some('#')) if self.edition >= Edition::Rust2021 => {
+                self.advance();
+
+                let kind = self.fin_lex_prefixed_ident(
+                    IdentKind::Normal,
+                    None,
+                    |ident| ident != TokenKind::CommonIdent,
+                    |_| ErrorKind::InvalidStroppedKeyword,
+                    std::convert::identity,
+                    start,
+                );
+
+                self.store.features.add((Feature::__stropped_keywords, Some(self.span(start))));
+
+                return kind;
+            }
             ("r", Some('#')) => {
                 self.advance();
 
-                return match self.fin_lex_raw_ident(IdentKind::Normal, start) {
-                    Some(()) => TokenKind::CommonIdent,
-                    None => self.fin_lex_raw_guarded_str_lit(start),
-                };
+                return self.fin_lex_prefixed_ident(
+                    IdentKind::Normal,
+                    Some(|this, start| this.fin_lex_raw_guarded_str_lit(start)),
+                    |ident| !matches!(ident, PathSegKeyword!() | TokenKind::Underscore),
+                    ErrorKind::InvalidRawIdent,
+                    |_| TokenKind::CommonIdent,
+                    start,
+                );
             }
             (_, Some(char @ ('"' | '\'' | '#'))) if self.edition >= Edition::Rust2021 => {
                 self.error(ErrorKind::ReservedPrefix, self.span(start));
@@ -614,22 +632,36 @@ impl<'sto, 'src> Lexer<'sto, 'src> {
         self.fin_lex_str_lit(raw, flavor, start)
     }
 
-    fn fin_lex_raw_ident(&mut self, kind: IdentKind, start: ByteIndex) -> Option<()> {
+    fn fin_lex_prefixed_ident(
+        &mut self,
+        kind: IdentKind,
+        fallback: Option<fn(&mut Self, ByteIndex) -> TokenKind>,
+        validate: fn(TokenKind) -> bool,
+        error: fn(IdentKind) -> ErrorKind,
+        map: fn(TokenKind) -> TokenKind,
+        start: ByteIndex,
+    ) -> TokenKind {
         if !self.peek().is_some_and(is_ident_start) {
-            return None;
+            return match fallback {
+                Some(fallback) => fallback(self, start),
+                None => {
+                    self.error(error(kind), self.span(start));
+                    TokenKind::Error
+                }
+            };
         }
 
         let unprefixed = self.index();
         self.advance();
         self.advance_while(is_ident_middle);
 
-        if let PathSegKeyword!() | TokenKind::Underscore =
-            lex_ident(self.source(unprefixed), self.edition)
-        {
-            self.error(ErrorKind::InvalidRawIdent(kind), self.span(start));
+        let ident = lex_ident(self.source(unprefixed), self.edition);
+
+        if !validate(ident) {
+            self.error(error(kind), self.span(start));
         }
 
-        Some(())
+        map(ident)
     }
 
     // FIXME: Consolidate with `fin_lex_str_lit` smh

--- a/src/lib/lexer.rs
+++ b/src/lib/lexer.rs
@@ -447,27 +447,44 @@ impl<'sto, 'src> Lexer<'sto, 'src> {
                     return TokenKind::CharLit;
                 }
                 Some('#') if self.edition >= Edition::Rust2021 => {
-                    if self.source(unticked) != "r" {
-                        self.error(ErrorKind::ReservedPrefix, self.span(unticked));
-                        self.advance(); // `#`
-                        return TokenKind::Error;
-                    }
+                    let mode = match self.source(unticked) {
+                        "k" => IdentMode::Keyword,
+                        "r" => IdentMode::Raw,
+                        _ => {
+                            self.error(ErrorKind::ReservedPrefix, self.span(unticked));
+                            self.advance(); // `#`
+                            return TokenKind::Error;
+                        }
+                    };
                     self.advance();
 
                     let kind = self.fin_lex_prefixed_ident(
                         IdentKind::Ticked,
+                        mode,
                         None,
-                        |ident| !matches!(ident, PathSegKeyword!() | TokenKind::Underscore),
-                        ErrorKind::InvalidRawIdent,
+                        |ident, mode| match (mode, ident) {
+                            | (IdentMode::Keyword, TokenKind::CommonIdent)
+                            | (IdentMode::Raw, PathSegKeyword!() | TokenKind::Underscore) => false,
+                            _ => true,
+                        },
                         |_| TokenKind::TickedIdent,
                         start,
                     );
 
-                    // This is considered to be a 'reservation'.
-                    if kind != TokenKind::Error // FIXME: HACK
-                        && let Some('\'') = self.peek()
-                    {
-                        self.error(ErrorKind::TickFollowingRawTickedIdent, self.span(self.index()));
+                    // FIXME: HACK: checking against error
+                    if kind != TokenKind::Error {
+                        // This is considered to be a 'reservation'.
+                        if let Some('\'') = self.peek() {
+                            // FIXME: Generalize to also include stropped keywords!
+                            self.error(
+                                ErrorKind::TickFollowingRawTickedIdent,
+                                self.span(self.index()),
+                            );
+                        } else {
+                            self.store
+                                .features
+                                .add((Feature::__stropped_keywords, Some(self.span(start))));
+                        }
                     }
 
                     return kind;
@@ -596,9 +613,9 @@ impl<'sto, 'src> Lexer<'sto, 'src> {
 
                 let kind = self.fin_lex_prefixed_ident(
                     IdentKind::Normal,
+                    IdentMode::Keyword,
                     None,
-                    |ident| ident != TokenKind::CommonIdent,
-                    |_| ErrorKind::InvalidStroppedKeyword,
+                    |ident, _| ident != TokenKind::CommonIdent,
                     std::convert::identity,
                     start,
                 );
@@ -612,9 +629,9 @@ impl<'sto, 'src> Lexer<'sto, 'src> {
 
                 return self.fin_lex_prefixed_ident(
                     IdentKind::Normal,
+                    IdentMode::Raw,
                     Some(|this, start| this.fin_lex_raw_guarded_str_lit(start)),
-                    |ident| !matches!(ident, PathSegKeyword!() | TokenKind::Underscore),
-                    ErrorKind::InvalidRawIdent,
+                    |ident, _| !matches!(ident, PathSegKeyword!() | TokenKind::Underscore),
                     |_| TokenKind::CommonIdent,
                     start,
                 );
@@ -635,9 +652,9 @@ impl<'sto, 'src> Lexer<'sto, 'src> {
     fn fin_lex_prefixed_ident(
         &mut self,
         kind: IdentKind,
+        mode: IdentMode,
         fallback: Option<fn(&mut Self, ByteIndex) -> TokenKind>,
-        validate: fn(TokenKind) -> bool,
-        error: fn(IdentKind) -> ErrorKind,
+        validate: fn(TokenKind, IdentMode) -> bool,
         map: fn(TokenKind) -> TokenKind,
         start: ByteIndex,
     ) -> TokenKind {
@@ -645,7 +662,7 @@ impl<'sto, 'src> Lexer<'sto, 'src> {
             return match fallback {
                 Some(fallback) => fallback(self, start),
                 None => {
-                    self.error(error(kind), self.span(start));
+                    self.error(ErrorKind::InvalidIdent(kind, mode), self.span(start));
                     TokenKind::Error
                 }
             };
@@ -657,8 +674,8 @@ impl<'sto, 'src> Lexer<'sto, 'src> {
 
         let ident = lex_ident(self.source(unprefixed), self.edition);
 
-        if !validate(ident) {
-            self.error(error(kind), self.span(start));
+        if !validate(ident, mode) {
+            self.error(ErrorKind::InvalidIdent(kind, mode), self.span(start));
         }
 
         map(ident)
@@ -818,6 +835,12 @@ impl Iterator for Lexer<'_, '_> {
 pub enum IdentKind {
     Normal,
     Ticked,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum IdentMode {
+    Raw,
+    Keyword,
 }
 
 #[derive(Clone, Copy)]

--- a/src/lib/parser/common.rs
+++ b/src/lib/parser/common.rs
@@ -61,6 +61,7 @@ impl<'src> super::Parser<'_, '_, 'src> {
         self.advance();
 
         let source = &self.source(span)[const { "'".len() }..];
+        let source = source.strip_prefix("k#").unwrap_or(source);
         let ident = lex_ident(source, self.edition);
         if !validate(ident) {
             self.error(error, span);

--- a/src/lib/parser/test/misc.rs
+++ b/src/lib/parser/test/misc.rs
@@ -1,3 +1,4 @@
+use super::super::Fragment;
 use super::{parse_expr, parse_file, parse_item, parse_pat, parse_ty, t};
 use crate::{
     ast,
@@ -498,5 +499,51 @@ fn char_lits_or_ticked_idents() {
         Rust2021,
         "M! { 'r#a'r#a }",
         Err([Error { kind: ErrorKind::TickFollowingRawTickedIdent, .. }])
+    );
+}
+
+#[test]
+fn stropped_keywords() {
+    t!(
+        parse_item,
+        Rust2021,
+        "k#fn diverge() -> ! { k#loop {} }",
+        Ok(ast::Item {
+            kind: ast::ItemKind::Fn(ast::FnItem {
+                binder: ast::Ident!("diverge"),
+                body: Some(ast::BlockExpr {
+                    stmts: [ast::Stmt::Expr(ast::Expr { kind: ast::ExprKind::Loop(..), .. }, _)]
+                }),
+                ..
+            }),
+            ..
+        })
+    );
+
+    // Using a macro call to demonstrate that this is a lexical error even!
+    t!(
+        parse_item,
+        Rust2021,
+        "Q![ k# ];",
+        Err([Error { kind: ErrorKind::InvalidStroppedKeyword, .. }])
+    );
+    t!(
+        parse_item,
+        Rust2021,
+        "Q![ k#common ];",
+        Err([Error { kind: ErrorKind::InvalidStroppedKeyword, .. }])
+    );
+
+    t!(
+        parse_expr,
+        Rust2018,
+        "k#loop {}",
+        Err([Error {
+            kind: ErrorKind::UnexpectedToken(
+                TokenKind::Hash,
+                [Fragment::Token(TokenKind::EndOfInput)]
+            ),
+            ..
+        }])
     );
 }

--- a/src/lib/parser/test/misc.rs
+++ b/src/lib/parser/test/misc.rs
@@ -4,7 +4,7 @@ use crate::{
     ast,
     edition::Edition::*,
     error::{Error, ErrorKind},
-    lexer::IdentKind,
+    lexer::{IdentKind, IdentMode},
     token::{Token, TokenKind},
 };
 
@@ -277,8 +277,8 @@ fn raw_idents() {
         Rust2015,
         "K!(r#self r#_);",
         Err([
-            Error { kind: ErrorKind::InvalidRawIdent(IdentKind::Normal), .. },
-            Error { kind: ErrorKind::InvalidRawIdent(IdentKind::Normal), .. }
+            Error { kind: ErrorKind::InvalidIdent(IdentKind::Normal, IdentMode::Raw), .. },
+            Error { kind: ErrorKind::InvalidIdent(IdentKind::Normal, IdentMode::Raw), .. }
         ])
     );
 
@@ -375,12 +375,11 @@ fn raw_ticked_idents() {
             ..
         })
     );
-
     t!(
         parse_item,
         Rust2021,
         "type R = &'r#_ ();",
-        Err([Error { kind: ErrorKind::InvalidRawIdent(IdentKind::Ticked), .. }])
+        Err([Error { kind: ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Raw), .. }])
     );
 
     // We once used to accept this by mistake!
@@ -390,8 +389,8 @@ fn raw_ticked_idents() {
         Rust2021,
         "seg!('r#self 'r#Self);",
         Err([
-            Error { kind: ErrorKind::InvalidRawIdent(IdentKind::Ticked), .. },
-            Error { kind: ErrorKind::InvalidRawIdent(IdentKind::Ticked), .. },
+            Error { kind: ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Raw), .. },
+            Error { kind: ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Raw), .. },
         ])
     );
 
@@ -400,7 +399,7 @@ fn raw_ticked_idents() {
         parse_item,
         Rust2021,
         "W!('r#0);",
-        Err([Error { kind: ErrorKind::InvalidRawIdent(IdentKind::Ticked), .. }])
+        Err([Error { kind: ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Raw), .. }])
     );
 
     // We once used to accept this by mistake treating it as an empty raw ticked ident!
@@ -408,7 +407,7 @@ fn raw_ticked_idents() {
         parse_item,
         Rust2021,
         "O!('r#);",
-        Err([Error { kind: ErrorKind::InvalidRawIdent(IdentKind::Ticked), .. }])
+        Err([Error { kind: ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Raw), .. }])
     );
 }
 
@@ -479,7 +478,7 @@ fn char_lits_or_ticked_idents() {
         Rust2021,
         "W!('r#');",
         Err([
-            Error { kind: ErrorKind::InvalidRawIdent(IdentKind::Ticked), .. },
+            Error { kind: ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Raw), .. },
             Error { kind: ErrorKind::UnterminatedCharLit, .. },
             Error { kind: ErrorKind::MissingClosingDelimiters, .. },
         ])
@@ -525,13 +524,13 @@ fn stropped_keywords() {
         parse_item,
         Rust2021,
         "Q![ k# ];",
-        Err([Error { kind: ErrorKind::InvalidStroppedKeyword, .. }])
+        Err([Error { kind: ErrorKind::InvalidIdent(IdentKind::Normal, IdentMode::Keyword), .. }])
     );
     t!(
         parse_item,
         Rust2021,
         "Q![ k#common ];",
-        Err([Error { kind: ErrorKind::InvalidStroppedKeyword, .. }])
+        Err([Error { kind: ErrorKind::InvalidIdent(IdentKind::Normal, IdentMode::Keyword), .. }])
     );
 
     t!(
@@ -546,4 +545,64 @@ fn stropped_keywords() {
             ..
         }])
     );
+}
+
+#[test]
+fn stropped_ticked_keywords() {
+    // FIXME: Both `'r#static` and `'k#static` are legal. Does that really make sense?
+    //        I'm already confused why `'r#_` is illegal but `'r#static` is not.
+    t!(
+        parse_ty,
+        Rust2021,
+        "&'k#static ()",
+        Ok(ast::Ty::Ref(ast::RefTy { lt: Some(ast::Lifetime(ast::Ident!("static"))), .. }))
+    );
+
+    t!(
+        parse_ty,
+        Rust2021,
+        "&'k#_ ()",
+        Ok(ast::Ty::Ref(ast::RefTy { lt: Some(ast::Lifetime(ast::Ident!("_"))), .. }))
+    );
+
+    // These are lexically accepted despite
+    // * `'static` not being a valid label and
+    // * `'if` not being a valid lifetime or label.
+    // That's fine because non-stropped ticked "keywords" are also lexically allowed.
+    // Only syntactically they may be invalid.
+    t!(parse_item, Rust2021, "T!( 'k#static );", Ok(_));
+    t!(parse_item, Rust2021, "T!( 'k#if );", Ok(_));
+
+    // Using a macro call to demonstrate that this is a lexical error even!
+    t!(
+        parse_item,
+        Rust2021,
+        "T!( 'k#common );",
+        Err([Error { kind: ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Keyword), .. }])
+    );
+
+    // Using a macro call to demonstrate that this is a lexical error even!
+    t!(
+        parse_item,
+        Rust2021,
+        "U!( 'k# );",
+        Err([Error { kind: ErrorKind::InvalidIdent(IdentKind::Ticked, IdentMode::Keyword), .. }])
+    );
+
+    t!(
+        parse_ty,
+        Rust2018,
+        "&'k#static ();",
+        Err([Error { kind: ErrorKind::UnexpectedToken(TokenKind::Hash, _), .. }])
+    );
+
+    // While `'k#static` is lexically valid, it's not syntactically valid as a label:
+    t!(
+        parse_expr,
+        Rust2021,
+        "'k#static: loop {}",
+        Err([Error { kind: ErrorKind::ReservedLabel, .. }])
+    );
+
+    t!(parse_expr, Rust2021, "'k#_: loop {}", Err([Error { kind: ErrorKind::ReservedLabel, .. }]));
 }


### PR DESCRIPTION
See accepted MCP https://github.com/rust-lang/compiler-team/issues/945 & its tracking issue https://github.com/rust-lang/rust/issues/153839.
This PR is now blocked on rustc impl'ing this feature.

NB: Neither the RFC nor the MCP mention stropped ticked keywords ("raw keyword lifetimes"). Still, I've implemented them here. The RFC predates raw lifetimes, so it's obvious why it wasn't brought up back then.